### PR TITLE
Add RubyMine .idea folder and .rvmrc file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist/
 tmp/
 tests/source/
 .DS_Store
+.idea/
+.rvmrc
 


### PR DESCRIPTION
RubyMine creates a .idea folder for its metadata which should not be in the repository.  Also, .rvmrc should not be in the repository, unless you require a specific setup.
