### PR TITLE
Readonly gem refs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist/
 tmp/
 tests/source/
 .DS_Store
+.idea/
+.rvmrc
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source "http://rubygems.org"
 
-gem "sproutcore", :git => "https://github.com/wycats/abbot-from-scratch.git"
+gem "sproutcore", :git => "git://github.com/wycats/abbot-from-scratch.git"
 gem "uglifier", "~> 1.0.3"
 gem "execjs", "~> 1.2.6"
 gem "rack"
-gem "rake-pipeline", :git => "https://github.com/livingsocial/rake-pipeline.git"
-gem "rake-pipeline-web-filters", :git => "https://github.com/wycats/rake-pipeline-web-filters.git"
+gem "rake-pipeline", :git => "git://github.com/livingsocial/rake-pipeline.git"
+gem "rake-pipeline-web-filters", :git => "git://github.com/wycats/rake-pipeline-web-filters.git"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 GIT
-  remote: https://github.com/livingsocial/rake-pipeline.git
-  revision: 56bbc5d9cf7ce1b69d29d3d6af7282603dcdebba
+  remote: git://github.com/livingsocial/rake-pipeline.git
+  revision: 543f4322fe70facee9572d29ddabf7f090dad68a
   specs:
-    rake-pipeline (0.5.0)
+    rake-pipeline (0.6.0)
       rake (~> 0.9.0)
       thor
 
 GIT
-  remote: https://github.com/wycats/abbot-from-scratch.git
-  revision: 29dfaa6c3c120847e61f742f74c414e4872cc142
+  remote: git://github.com/wycats/abbot-from-scratch.git
+  revision: 47662bbbb25afc213318051676cd31375d1d1f59
   specs:
     sproutcore (0.0.1)
 
 GIT
-  remote: https://github.com/wycats/rake-pipeline-web-filters.git
-  revision: e7273a0c5df7181c9cc0bca31cb3dec7fa39fcc8
+  remote: git://github.com/wycats/rake-pipeline-web-filters.git
+  revision: 81a22fb0808dfdeab8ed92d5d8c898ad198b9938
   specs:
-    rake-pipeline-web-filters (0.5.0)
+    rake-pipeline-web-filters (0.6.0)
       rack
-      rake-pipeline
+      rake-pipeline (~> 0.6)
 
 GEM
   remote: http://rubygems.org/
@@ -28,7 +28,7 @@ GEM
     multi_json (1.0.4)
     rack (1.4.0)
     rake (0.9.2.2)
-    thor (0.14.6)
+    thor (0.15.2)
     uglifier (1.0.4)
       execjs (>= 0.3.0)
       multi_json (>= 1.0.2)


### PR DESCRIPTION
The gem references for git repos had https references which did not work for those without repo access.  The read-only references did work.  If this was a github issue this may not be needed, but ti resolved my issue with bundling the gems.
