### PR TITLE
Text support

### DIFF
--- a/packages/ember-bootstrap/lib/forms/text_area.js
+++ b/packages/ember-bootstrap/lib/forms/text_area.js
@@ -1,8 +1,9 @@
+require("ember-bootstrap/mixins/text_support");
+
 Bootstrap.Forms.TextArea = Bootstrap.Forms.Field.extend({
 
-  inputField: Ember.TextArea.extend({
-    valueBinding: 'parentView.value',
-    nameBinding: 'parentView.label',
-    attributeBindings: ['name']
+  inputField: Ember.TextArea.extend(Bootstrap.TextSupport, {
+    rowsBinding: 'parentView.rows',
+    colsBinding: 'parentView.cols'
   })
 });

--- a/packages/ember-bootstrap/lib/forms/text_field.js
+++ b/packages/ember-bootstrap/lib/forms/text_field.js
@@ -1,8 +1,10 @@
-Bootstrap.Forms.TextField = Bootstrap.Forms.Field.extend({
+require("ember-bootstrap/mixins/text_support");
 
-  inputField: Ember.TextField.extend({
-    valueBinding: 'parentView.value',
-    nameBinding: 'parentView.label',
-    attributeBindings: ['name']
+Bootstrap.Forms.TextField = Bootstrap.Forms.Field.extend({
+  type: 'text',
+
+  inputField: Ember.TextField.extend(Bootstrap.TextSupport, {
+    typeBinding: 'parentView.type',
+    sizeBinding: 'parentView.size'
   })
 });

--- a/packages/ember-bootstrap/lib/mixins/text_support.js
+++ b/packages/ember-bootstrap/lib/mixins/text_support.js
@@ -1,0 +1,11 @@
+var getPath = Ember.getPath;
+
+Bootstrap.TextSupport = Ember.Mixin.create({
+  valueBinding: 'parentView.value',
+  placeholderBinding: 'parentView.placeholder',
+  disabledBinding: 'parentView.disabled',
+  maxlengthBinding: 'parentView.maxlength',
+  nameBinding: 'parentView.label',
+  attributeBindings: ['name']
+});
+

--- a/packages/ember-bootstrap/lib/mixins/text_support.js
+++ b/packages/ember-bootstrap/lib/mixins/text_support.js
@@ -5,7 +5,9 @@ Bootstrap.TextSupport = Ember.Mixin.create({
   placeholderBinding: 'parentView.placeholder',
   disabledBinding: 'parentView.disabled',
   maxlengthBinding: 'parentView.maxlength',
-  nameBinding: 'parentView.label',
-  attributeBindings: ['name']
+  classNameBindings: 'parentView.inputClassNames',
+  attributeBindings: ['name'],
+  name: Ember.computed(function() {
+    return getPath(this, 'parentView.name') || getPath(this, 'parentView.label');
+  }).property('parentView.name', 'parentView.label').cacheable()
 });
-

--- a/packages/ember-bootstrap/tests/forms/controls/text_area_test.js
+++ b/packages/ember-bootstrap/tests/forms/controls/text_area_test.js
@@ -39,3 +39,14 @@ test("input value is updated when setting value property of view", function() {
 
   equal(textArea.val(), "bar", "updates text field after value changes");
 });
+
+test("input cols and rows can be set", function() {
+  Ember.run(function() {
+    field.set('cols', '60');
+    field.set('rows', '3');
+    field.append();
+  });
+  textArea = field.$().find('textarea')
+  equal(textArea.attr('cols'), "60", "sets cols attribute on textarea");
+  equal(textArea.attr('rows'), "3", "sets rows attribute on textarea");
+});

--- a/packages/ember-bootstrap/tests/forms/controls/text_field_test.js
+++ b/packages/ember-bootstrap/tests/forms/controls/text_field_test.js
@@ -39,3 +39,27 @@ test("input value is updated when setting value property of view", function() {
 
   equal(textField.val(), "bar", "updates text field after value changes");
 });
+
+test("input type and size can be set", function() {
+  Ember.run(function() {
+    field.set('type', 'number');
+    field.set('size', '60');
+    field.append();
+  });
+  textField = field.$().find('input[type]')
+  equal(textField.attr('type'), "number", "sets input type to number");
+  equal(textField.attr('size'), "60", "sets input size of input");
+});
+
+test("input  attributes can be set", function() {
+  Ember.run(function() {
+    field.set('placeholder', "First Name");
+    field.set('disabled', true);
+    field.set('maxlength', '60');
+    field.append();
+  });
+  textField = field.$().find('input[type=text]')
+  equal(textField.attr('placeholder'), "First Name", "sets input placeholder from parent");
+  equal(textField.prop('disabled'), true, "sets disabled from parent");
+  equal(textField.prop('maxlength'), 60, "sets maxlength from parent");
+});

--- a/packages/ember-bootstrap/tests/forms/controls/text_field_test.js
+++ b/packages/ember-bootstrap/tests/forms/controls/text_field_test.js
@@ -63,3 +63,25 @@ test("input  attributes can be set", function() {
   equal(textField.prop('disabled'), true, "sets disabled from parent");
   equal(textField.prop('maxlength'), 60, "sets maxlength from parent");
 });
+
+test("input name can be set from name or label", function() {
+  Ember.run(function() {
+    field.set('label', 'First Name');
+    field.append();
+  });
+  textField = field.$().find('input[type=text]')
+  equal(textField.attr('name'), "First Name", "sets name from label");
+
+  Ember.run(function() { field.set('label', 'first_name'); });
+
+  equal(textField.attr('name'), "first_name", "sets name from parent if available");
+});
+
+test("inputClasses can be set from parent", function() {
+  Ember.run(function() {
+    field.set('inputClassNames', ['input-small']);
+    field.append();
+  });
+  textField = field.$().find('input[type=text]')
+  equal(textField.hasClass("input-small"), true, "sets classes on input");
+});


### PR DESCRIPTION
I've made some changes to TextArea and TextField.

I extended TextArea and TextInput to support all the attributes supported by Ember.TextField and Ember.TextArea by creating a TextSupport mixin.

The second commit adds two other changes:
 An inputClassNames attribute to set classNames on the input and I've made the name attribute look for a name attribute before using the label.

Thoughts?
