### PR TITLE
Use defaultTemplate for the modal 

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -14,7 +14,7 @@ var modalPaneBackdrop = '<div class="modal-backdrop"></div>';
 
 Bootstrap.ModalPane = Ember.View.extend({
   classNames: 'modal',
-  template: Ember.Handlebars.compile(modalPaneTemplate),
+  defaultTemplate: Ember.Handlebars.compile(modalPaneTemplate),
   heading: null,
   message: null,
   primary: null,


### PR DESCRIPTION
This makes it possible to override the modal template with a named template
