### PR TITLE
Minor fix in modalPaneTemplate

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -3,9 +3,9 @@ var get = Ember.get;
 var modalPaneTemplate = '\
 <div class="modal-header"> \
   <a href="#" class="close" rel="close">×</a> \
-  {{view view.headerViewClass}} \
+  {{heading}} \
 </div> \
-<div class="modal-body">{{view view.bodyViewClass}}</div> \
+<div class="modal-body">{{message}}</div> \
 <div class="modal-footer"> \
   {{#if view.secondary}}<a href="#" class="btn btn-secondary" rel="secondary">{{view.secondary}}</a>{{/if}} \
   {{#if view.primary}}<a href="#" class="btn btn-primary" rel="primary">{{view.primary}}</a>{{/if}} \


### PR DESCRIPTION
Not sure if this was intended, but yesterday I started trying out Ember-Bootstrap and I noticed that when I call `ModalPane` View, it was not displaying the header or message texts in the modal. Changed the template from `view.headerViewClass` and `view.bodyViewClass` to `heading` and `message` respectively.
