### PR TITLE
Use github_downloads gem to upload latest version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/
 tmp/
 tests/source/
 tests/ember-bootstrap-tests.js
+
+# .github-upload-token stores OAuth token, used by github_downloads gem
+.github-upload-token

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,7 @@ gem "uglifier", "~> 1.0.3"
 
 group :development do
   gem "rack"
-  gem "rest-client"
-  gem "github_api"
+  gem "github_downloads"
   gem "ember-docs", :git => "https://github.com/emberjs/docs-generator.git"
   gem "kicker"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,17 +31,19 @@ GEM
     faraday (0.8.1)
       multipart-post (~> 1.1)
     ffi (1.0.11)
-    github_api (0.6.1)
+    github_api (0.6.3)
       faraday (~> 0.8.1)
       hashie (~> 1.2.0)
       multi_json (~> 1.3)
       nokogiri (~> 1.5.2)
       oauth2
+    github_downloads (0.1.2)
+      github_api (~> 0.6)
+      rest-client (~> 1.6)
     hashie (1.2.0)
     httpauth (0.1)
-    json (1.7.3)
-    jwt (0.1.4)
-      json (>= 1.2.4)
+    jwt (0.1.5)
+      multi_json (>= 1.0)
     kicker (2.6.1)
       listen
     listen (0.4.7)
@@ -78,10 +80,9 @@ PLATFORMS
 DEPENDENCIES
   colored
   ember-docs!
-  github_api
+  github_downloads
   kicker
   rack
   rake-pipeline!
   rake-pipeline-web-filters!
-  rest-client
   uglifier (~> 1.0.3)

--- a/Rakefile
+++ b/Rakefile
@@ -10,25 +10,8 @@ def pipeline
 end
 
 def setup_uploader
-  require './lib/github_uploader'
-
-  # get the github user name
-  login = `git config github.user`.chomp
-
-  # get repo from git config's origin url
-  origin = `git config remote.origin.url`.chomp # url to origin
-  # extract USERNAME/REPO_NAME
-  # sample urls: https://github.com/emberjs/ember.js.git
-  #              git://github.com/emberjs/ember.js.git
-  #              git@github.com:emberjs/ember.js.git
-  #              git@github.com:emberjs/ember.js
-
-  repoUrl = origin.match(/github\.com[\/:]((.+?)\/(.+?))(\.git)?$/)
-  username = repoUrl[2] # username part of origin url
-  repo = repoUrl[3] # repository name part of origin url
-
-  token = ENV["GH_OAUTH_TOKEN"]
-  uploader = GithubUploader.new(login, username, repo, token)
+  require 'github_downloads'
+  uploader = GithubDownloads::Uploader.new
   uploader.authorize
 
   uploader


### PR DESCRIPTION
This enables the upload of latest version of `ember-bootstrap` to GitHub Downloads via `rake upload_latest` ...
