### PR TITLE
Link Bootstrap.Form.Field labels and inputs properly.

### DIFF
--- a/packages/ember-bootstrap/lib/forms.js
+++ b/packages/ember-bootstrap/lib/forms.js
@@ -5,7 +5,7 @@ window.Bootstrap.Forms = Ember.Namespace.create({
       return;
 
     // Replace all _ with spaces
-    value = value.replace(/_/, " ");
+    value = value.replace(/_/g, " ");
     // Capitalize the first letter of every word
     value = value.replace(/(^|\s)([a-z])/g, function(m,p1,p2){ return p1+p2.toUpperCase(); });
     return value;

--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -5,7 +5,7 @@ Bootstrap.Forms.Field = Ember.View.extend({
   template: Ember.Handlebars.compile([
     '{{view view.labelView}}',
     '<div class="controls">',
-    '  {{view view.inputField}}',
+    '  {{view view.inputField viewName="inputFieldView"}}',
     '  {{view view.errorsView}}',
     '</div>'].join("\n")),
 
@@ -26,7 +26,7 @@ Bootstrap.Forms.Field = Ember.View.extend({
       return Bootstrap.Forms.human(value);
     }).property('parentView.label'),
 
-    forBinding: 'value',
+    forBinding: 'parentView.inputFieldView.elementId',
     attributeBindings: ['for']
   }),
 

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -27,6 +27,12 @@ test("should have the label", function() {
   equal(field.$().find('label.control-label').length, 1, "Every field needs to include a label");
 });
 
+test("should set the label's for attribute to the id of the input", function() {
+  append();
+  var inputId = field.$().find('div.ember-bootstrap-extend').attr('id');
+  equal(field.$().find('label.control-label').attr('for'), inputId, "The label's for value should be the input's ID");
+});
+
 test("should set the label value", function() {
   append();
 

--- a/packages/ember-bootstrap/tests/forms_test.js
+++ b/packages/ember-bootstrap/tests/forms_test.js
@@ -5,6 +5,6 @@ module("Bootstrap", {});
 test("human", function() {
   equal(Bootstrap.Forms.human(), undefined, "should not fail with undefined");
 
-  equal(Bootstrap.Forms.human("hello world"), "Hello World", "should capitalize all the words");
-  equal(Bootstrap.Forms.human("hello_world"), "Hello World", "should replace _ with spaces");
+  equal(Bootstrap.Forms.human("hello there world"), "Hello There World", "should capitalize all the words");
+  equal(Bootstrap.Forms.human("hello_there_world"), "Hello There World", "should replace _ with spaces");
 });


### PR DESCRIPTION
Bootstrap.Form.Field labels now use the `id` of the input as the `for` attribute as per common usage.

Fixed another bug where the label wasn't properly generated if it contained multiple underscores as well.

```
{{view Bootstrap.Forms.TextField valueBinding="content" label="my_awesome_label"}}
```

now generates 

```
<div id="emberxxxx" class="ember-view control-group">
  <label id="emberxxxx" class="ember-view control-label" for="ember1234">
    My Awesome Label
  </label>
  <div class="controls">
    <input id="ember1234" class="ember-view ember-text-field" type="text" name="my_awesome_label">
  </div>
  ... errors
</div>
```
