### PR TITLE
Allow modal pane to override closing

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -79,9 +79,12 @@ Bootstrap.ModalPane = Ember.View.extend({
   },
 
   _triggerCallbackAndDestroy: function(options, event) {
-    if (this.callback) this.callback(options, event);
-    this.destroy();
-  }
+    var destroy;
+    if (this.callback) {
+      destroy = this.callback(options, event);
+    }
+    if (destroy === undefined || destroy) this.destroy();
+  }  
 });
 
 Bootstrap.ModalPane.reopenClass({

--- a/packages/ember-bootstrap/tests/views/modal_pane_test.js
+++ b/packages/ember-bootstrap/tests/views/modal_pane_test.js
@@ -121,6 +121,51 @@ test("a modal pane calls callback when primary button clicked and removes pane f
   ok(isDestroyed(modalPane), "modal pane is destroyed");
 });
 
+test("a modal pane calls callback when primary button clicked which cancels removes pane from the DOM", function() {
+  var callback = function() { callbackWasCalled = true; return false;},
+      callbackWasCalled = false;
+  modalPane = Bootstrap.ModalPane.create({
+    primary: 'Primary button',
+    callback: callback
+  });
+  appendIntoDOM(modalPane);
+  clickRelLink(modalPane, 'primary');
+  ok(callbackWasCalled, "modal pane calls given callback when primary button clicked");
+  ok(isAppendedToDOM(modalPane), "modal pane is in the DOM");
+  ok(!isDestroyed(modalPane), "modal pane is not destroyed");
+});
+
+test("a modal pane calls callback when primary button clicked which explicitly removes pane from the DOM", function() {
+  var callback = function() { callbackWasCalled = true; return true;},
+      callbackWasCalled = false;
+  modalPane = Bootstrap.ModalPane.create({
+    primary: 'Primary button',
+    callback: callback
+  });
+  appendIntoDOM(modalPane);
+  clickRelLink(modalPane, 'primary');
+  ok(callbackWasCalled, "modal pane calls given callback when primary button clicked");
+  ok(!isAppendedToDOM(modalPane), "modal pane is not in the DOM");
+  ok(isDestroyed(modalPane), "modal pane is destroyed");
+});
+
+test("a modal pane calls callback which explicitly removes pane after second click from the DOM", function() {
+  var callback = function() { callbackWasCalledCount++; return callbackWasCalledCount > 1;},
+      callbackWasCalledCount = 0;
+  modalPane = Bootstrap.ModalPane.create({
+    primary: 'Primary button',
+    callback: callback
+  });
+  appendIntoDOM(modalPane);
+  clickRelLink(modalPane, 'primary');
+  ok(isAppendedToDOM(modalPane), "modal pane is in the DOM");
+  ok(!isDestroyed(modalPane), "modal pane is not destroyed");
+  clickRelLink(modalPane, 'primary');
+  ok(callbackWasCalledCount === 2, "modal pane calls given callback when primary button clicked");
+  ok(!isAppendedToDOM(modalPane), "modal pane is not in the DOM");
+  ok(isDestroyed(modalPane), "modal pane is destroyed");
+});
+
 test("a modal pane calls callback when secondary button clicked and removes pane from the DOM", function() {
   var callback = function() { callbackWasCalled = true; },
       callbackWasCalled = false;


### PR DESCRIPTION
Let the modal pane callback decide to close the pane or not.  This allows the bodyViewClass to be overridden with a more complex template that contains fields which can be validated by the callback.

``` javascript
App.MyView = Bootstrap.ModalPane.extend({

  controllerBinding: 'App.myController',

  bodyViewClass: Em.View.extend({
    templateName: 'myTemplate'
  })
});

App.myController = Em.Controller.create({

  myId: null,
  myName: null,

  showMyView: function(event) {

    this.set('myId', null);
    this.set('myName', null);

    App.MyView.popup({
      heading: "My view",
      primary: "Add",
      secondary: "Cancel",
      showBackdrop: true,
      callback: function(opts, event) { 

        if (opts.primary) {

          // Validate 
          var isValid = true;
          var myId = App.get('myController.myId');
          if (! myId) {
            isValid = false;
          } else {
            var regExp = /^[a-zA-Z0-9\._\-]{3,36}$/;
            if (! regExp.test(myId)) {
              isValid = false;
            }
          }

          // Validate the name
          var name = App.get('myController.myName');
          if (! name) {
            isValid = false;
          }

          if (!isValid) {
            return false;
          }

          return true;

        } else if (opts.secondary) {
          // secondary button was pressed
        } else {
          // close was pressed
        }
      }
    });
  }
});
```

``` html
<script type="text/x-handlebars" data-template-name="myTemplate">
  {{view Bootstrap.Forms.TextField label="myid" valueBinding="myId" placeholder="id"}}
  {{view Bootstrap.Forms.TextField label="name" valueBinding="myName" placeholder="name"}}
</script>
```
