### PR TITLE
Default label value to the value binding

### DIFF
--- a/packages/ember-bootstrap/lib/forms.js
+++ b/packages/ember-bootstrap/lib/forms.js
@@ -1,7 +1,7 @@
 window.Bootstrap.Forms = Ember.Namespace.create({
 
   human: function(value) {
-    if (value === undefined)
+    if (value === undefined || value === false)
       return;
 
     // Underscore string

--- a/packages/ember-bootstrap/lib/forms.js
+++ b/packages/ember-bootstrap/lib/forms.js
@@ -4,6 +4,8 @@ window.Bootstrap.Forms = Ember.Namespace.create({
     if (value === undefined)
       return;
 
+    // Underscore string
+    value = Ember.String.decamelize(value);
     // Replace all _ with spaces
     value = value.replace(/_/g, " ");
     // Capitalize the first letter of every word

--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -2,6 +2,7 @@ var Bootstrap = window.Bootstrap;
 Bootstrap.Forms.Field = Ember.View.extend({
   tagName: 'div',
   classNames: ['control-group'],
+  labelCache: undefined,
   template: Ember.Handlebars.compile([
     '{{view view.labelView viewName="labelView"}}',
     '<div class="controls">',
@@ -11,14 +12,14 @@ Bootstrap.Forms.Field = Ember.View.extend({
 
   label: Ember.computed(function(key, value) {
     if(arguments.length === 1){
-      if(this.get('labelCache')){
-        return this.get('labelCache');
-      } else {
+      if(this.get('labelCache') === undefined){
         var path = this.get('valueBinding._from');
         if (path) {
           path = path.split(".");
           return path[path.length - 1];
         }
+      } else {
+        return this.get('labelCache');
       }
     } else {
       this.set('labelCache', value);
@@ -85,5 +86,5 @@ Bootstrap.Forms.Field = Ember.View.extend({
 
   didInsertElement: function() {
     this.set('labelView.inputElementId', this.get('inputField.elementId'));
-  }  
+  }
 });

--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -9,6 +9,23 @@ Bootstrap.Forms.Field = Ember.View.extend({
     '  {{view view.errorsView}}',
     '</div>'].join("\n")),
 
+  label: Ember.computed(function(key, value) {
+    if(arguments.length === 1){
+      if(this.get('labelCache')){
+        return this.get('labelCache');
+      } else {
+        var path = this.get('valueBinding._from');
+        if (path) {
+          path = path.split(".");
+          return path[path.length - 1];
+        }
+      }
+    } else {
+      this.set('labelCache', value);
+      return value;
+    }
+  }).property('valueBinding'),
+
   labelView: Ember.View.extend({
     tagName: 'label',
     classNames: ['control-label'],

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -57,6 +57,9 @@ test("should use the valueBinding value as a default label", function() {
 
   Ember.run(function() { field.set('label', 'bar'); });
   equal(field.$().find('label').text(), 'Bar', "the label value should be bar");
+
+  Ember.run(function() { field.set('label', false); });
+  equal(field.$().find('label').text(), "", "the field should not have a label when label='false'");
 });
 
 test("should have the controls", function() {

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -42,6 +42,23 @@ test("should have the label for attribute", function() {
   equal(field.$().find('label').attr('for'), field.$().find('div.ember-bootstrap-extend').attr('id'), "the label for attribute should be the id of the input field");
 });
 
+test("should use the valueBinding value as a default label", function() {
+  field.destroy();
+  field = null;
+  object = Ember.Object.create({
+    foo: null
+  });
+  field = Bootstrap.Forms.Field.create({
+    bindingContext: object,
+    valueBinding: 'bindingContext.foo'
+  });
+  append();
+  equal(field.$().find('label').text(), 'Foo', "the label value should be Foo");
+
+  Ember.run(function() { field.set('label', 'bar'); });
+  equal(field.$().find('label').text(), 'Bar', "the label value should be bar");
+});
+
 test("should have the controls", function() {
   append();
   equal(field.$().find('div.controls').length, 1, "Every field needs to include the controls");

--- a/packages/ember-bootstrap/tests/forms_test.js
+++ b/packages/ember-bootstrap/tests/forms_test.js
@@ -5,4 +5,6 @@ test("human", function() {
 
   equal(Bootstrap.Forms.human("hello there world"), "Hello There World", "should capitalize all the words");
   equal(Bootstrap.Forms.human("hello_there_world"), "Hello There World", "should replace _ with spaces");
+  equal(Bootstrap.Forms.human("helloThereWorld"), "Hello There World", "should decamelize");
+
 });

--- a/packages/ember-bootstrap/tests/forms_test.js
+++ b/packages/ember-bootstrap/tests/forms_test.js
@@ -1,7 +1,8 @@
 module("Bootstrap", {});
 
 test("human", function() {
-  equal(Bootstrap.Forms.human(), undefined, "should not fail with undefined");
+  equal(Bootstrap.Forms.human(), undefined,      "should not fail with undefined");
+  equal(Bootstrap.Forms.human(false), undefined, "should swallow false values");
 
   equal(Bootstrap.Forms.human("hello there world"), "Hello There World", "should capitalize all the words");
   equal(Bootstrap.Forms.human("hello_there_world"), "Hello There World", "should replace _ with spaces");


### PR DESCRIPTION
This pull request removes some repetition from the common case where the label is just the name of the variable.

``` handlebars
{{Bootstrap.Forms.Field valueBinding="firstName" label="first_name"}}
```

can now be simplified to 

``` handlebars
{{Bootstrap.Forms.Field valueBinding="firstName"}}
```

Any improvements on the implementation would be appreciated, but I think this would be a nice feature.
