### PR TITLE
Append a modal to .ember-application 

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -84,15 +84,17 @@ Bootstrap.ModalPane = Ember.View.extend({
       destroy = this.callback(options, event);
     }
     if (destroy === undefined || destroy) this.destroy();
-  }  
+  }
 });
 
 Bootstrap.ModalPane.reopenClass({
+  rootElement: ".ember-application",
   popup: function(options) {
-    var modalPane;
+    var modalPane, rootElement;
     if (!options) options = {};
     modalPane = this.create(options);
-    modalPane.append();
+    rootElement = get(this, 'rootElement');
+    modalPane.appendTo(rootElement);
     return modalPane;
   }
 });

--- a/packages/ember-bootstrap/tests/views/modal_pane_test.js
+++ b/packages/ember-bootstrap/tests/views/modal_pane_test.js
@@ -20,6 +20,16 @@ test("a modal pane can be created and appended to DOM using popup() call", funct
   ok(isAppendedToDOM(modalPane), 'a modal pane has a layer in the DOM');
 });
 
+test("a modal pane is appended to the application using popup() call", function() {
+  application.destroy();
+  var rootElement = Ember.$('<div id="app" />').appendTo('#qunit-fixture');
+  application = Ember.Application.create({rootElement: "#app"});
+  Ember.run(function() {
+    modalPane = Bootstrap.ModalPane.popup();
+  });
+  ok((rootElement.find(modalPane.$()).length), 'a modal pane is appended to the application');
+});
+
 test("a modal pane can be created and appended to DOM", function() {
   modalPane = Bootstrap.ModalPane.create();
   appendIntoDOM(modalPane);


### PR DESCRIPTION
Instead of the whole document so the modal works with an 
Ember application with rootElement set
Fixes #36
