### PR TITLE
Clicking a button does not trigger hashchange anymore

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -58,6 +58,7 @@ Bootstrap.ModalPane = Ember.View.extend({
     } else if (targetRel === 'secondary') {
       this._triggerCallbackAndDestroy({ secondary: true }, event);
     }
+    return false;
   },
 
   _appendBackdrop: function() {


### PR DESCRIPTION
When clicking on one of the buttons of the modal pane, a hashchange
event was triggered. This is most certainly not what you want.
