### PR TITLE
In Modal Pane, only return false if we take action on the targetrel.

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -53,12 +53,16 @@ Bootstrap.ModalPane = Ember.View.extend({
 
     if (targetRel === 'close') {
       this._triggerCallbackAndDestroy({ close: true }, event);
+      return false;
+
     } else if (targetRel === 'primary') {
       this._triggerCallbackAndDestroy({ primary: true }, event);
+      return false;
+
     } else if (targetRel === 'secondary') {
       this._triggerCallbackAndDestroy({ secondary: true }, event);
+      return false;
     }
-    return false;
   },
 
   _appendBackdrop: function() {


### PR DESCRIPTION
I overload the bodyViewClass of ModalPane to add more complex templates, such as forms with text fields, buttons, checkboxes etc.  The ModalPane click event always returns false which stops the event propagation, and this makes things like checkboxes not render properly.

The click event should only stop events if it actually needs to, i.e. a button that closes the modal is pressed, otherwise it should let them bubble up and be processed by other listeners.
