### PR TITLE
Add .help-block to Bootstrap.Forms.Field

### DIFF
--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -3,11 +3,13 @@ Bootstrap.Forms.Field = Ember.View.extend({
   tagName: 'div',
   classNames: ['control-group'],
   labelCache: undefined,
+  help: undefined,
   template: Ember.Handlebars.compile([
     '{{view view.labelView viewName="labelView"}}',
     '<div class="controls">',
     '  {{view view.inputField viewName="inputField"}}',
     '  {{view view.errorsView}}',
+    '  {{view view.helpView}}',
     '</div>'].join("\n")),
 
   label: Ember.computed(function(key, value) {
@@ -87,6 +89,13 @@ Bootstrap.Forms.Field = Ember.View.extend({
         }
       }
     }, 'parentView.context.isValid', 'parentView.label')
+  }),
+
+  helpView: Ember.View.extend({
+    tagName: 'div',
+    classNames: ['help-block'],
+    template: Ember.Handlebars.compile('{{view.content}}'),
+    contentBinding: 'parentView.help'
   }),
 
   didInsertElement: function() {

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -91,3 +91,13 @@ test("should display the errors", function() {
   ok(!field.$().hasClass('error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
 });
+
+test("should display the help", function() {
+  append();
+
+  field.set('help', "Where in the world are you?");
+  equal(field.$().find('.help-block').text(), "Where in the world are you?", "the help message should be displayed");
+
+  field.set('help', null);
+  equal(field.$().find('.help-block').text(), "", "the help message should not be displayed");
+});


### PR DESCRIPTION
Hi.
I added `.help-block` to fields because I think it's often-used.
