### PR TITLE
Return true on ItemSelectionSupport.click

### DIFF
--- a/packages/ember-bootstrap/lib/mixins/item_selection_support.js
+++ b/packages/ember-bootstrap/lib/mixins/item_selection_support.js
@@ -26,6 +26,6 @@ Bootstrap.ItemSelectionSupport = Ember.Mixin.create(Bootstrap.ItemViewValueSuppo
       value = null;
     }
     set(parentView, 'selection', value);
-    return false;
+    return true;
   }
 });


### PR DESCRIPTION
Playing with this and ember.js today. I "noticed" that routes
wouldn't change. So if I had a route of "foobar" it wouldn't
transition to that view.

I have very little JS skill and about a days worth of ember.js. So I am not sure of any other side affects of this change. I was using the 1.0.0-rc.1 version of ember.js.
