### PR TITLE
Check for errors on object through valueBinding

### DIFF
--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -71,14 +71,21 @@ Bootstrap.Forms.Field = Ember.View.extend({
 
       if (parent !== null) {
         var context = parent.get('context');
-        var label = parent.get('label');
 
         if (context !== null && !context.get('isValid')) {
           var errors = context.get('errors');
+          var path = parent.get('valueBinding._from');
 
-          if (errors !== undefined && label in errors) {
+          if (path) {
+            path = path.split(".");
+            path = path[path.length - 1];
+          } else {
+            path = parent.get('label');
+          }
+
+          if (errors !== undefined && path in errors) {
             parent.$().addClass('error');
-            this.$().html(errors[label].join(', '));
+            this.$().html(errors[path].join(', '));
           } else {
             parent.$().removeClass('error');
             this.$().html('');

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -78,10 +78,32 @@ test("should have the errors", function() {
   equal(field.$().find('div.errors').length, 1, "Every field needs to include the errors");
 });
 
-test("should display the errors", function() {
+test("should display the label errors", function() {
   append();
 
   object.set('errors', {object: ["can't be null"]});
+  object.set('isValid', false);
+  ok(field.$().hasClass('error'), "the element should have the error tag");
+  equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
+
+  object.set('errors', null);
+  object.set('isValid', true);
+  ok(!field.$().hasClass('error'), "the element should not have the error tag");
+  equal(field.$().find('.errors').text(), "", "no error should be display anymore");
+});
+
+test("should display the field errors", function() {
+  field.destroy();
+  field = null;
+  object = Ember.Object.create({
+    foo: null
+  });
+  field = Bootstrap.Forms.Field.create({
+    context: object,
+    valueBinding: 'context.foo'
+  });
+  append();
+  object.set('errors', {foo: ["can't be null"]});
   object.set('isValid', false);
   ok(field.$().hasClass('error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");


### PR DESCRIPTION
Currently, `errorView` looks for errors on the object using the `label` value. This might not always work, as the `label` value might not correspond to the object's field name. For example the following code looks for errors on the field with name `IBAN`, but it should be looking for `iban`. Currently the only way to do this is not providing a custom label, but ideally I want to have a humanized label value that is different from the field's name.

```
{{view Bootstrap.Forms.TextField valueBinding="iban" label="IBAN"}}
```

This PR is backwards compatible when not using a `valueBinding`. If a `valueBinding` is present, it will use that field to look for errors. I've also added a test for the new use case.
