### PR TITLE
Change Pager's unicode signs

### DIFF
--- a/packages/ember-bootstrap/lib/views/pager.js
+++ b/packages/ember-bootstrap/lib/views/pager.js
@@ -11,8 +11,8 @@ Bootstrap.Pager = Ember.CollectionView.extend({
     this._super();
     if (!this.get("content")) {
       this.set("content", Ember.A([
-                                  Ember.Object.create({ title: "&larr;" }), 
-                                  Ember.Object.create({ title: "&rarr;" })
+                                  Ember.Object.create({ title: "Previous" }), 
+                                  Ember.Object.create({ title: "Next" })
       ]));
     }
   },


### PR DESCRIPTION
The unicode signs don't get converted so I think it's safer to use "Next" and "Previous".

Chrome: 
![Screen Shot 2013-03-09 at 23 36 26](https://f.cloud.github.com/assets/648684/240403/3605ec3a-8912-11e2-856a-fdadcbc42694.png)

Safari:
![Screen Shot 2013-03-09 at 23 37 12](https://f.cloud.github.com/assets/648684/240404/4bd666d4-8912-11e2-962d-d6666a774560.png)
