### PR TITLE
Show errors for nested objects

### DIFF
--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -43,11 +43,11 @@ Bootstrap.Forms.Field = Ember.View.extend({
         value = parent.get('label');
       }
 
-      // If the labelCache property is present on parent, then the 
+      // If the labelCache property is present on parent, then the
       // label was set manually, and there's no need to humanise it.
-      // Otherwise, it comes from the binding and needs to be 
+      // Otherwise, it comes from the binding and needs to be
       // humanised.
-      return parent.get('labelCache') === undefined || parent.get('labelCache') === false ? 
+      return parent.get('labelCache') === undefined || parent.get('labelCache') === false ?
         Bootstrap.Forms.human(value) : value;
     }).property('parentView.label'),
 
@@ -70,22 +70,25 @@ Bootstrap.Forms.Field = Ember.View.extend({
       var parent = this.get('parentView');
 
       if (parent !== null) {
-        var context = parent.get('context');
+        var binding = parent.get('valueBinding._from');
+        var fieldName = null;
+        var object = null;
 
-        if (context !== null && !context.get('isValid')) {
-          var errors = context.get('errors');
-          var path = parent.get('valueBinding._from');
+        if (binding) {
+          binding = binding.replace("_parentView.", "").split(".");
+          fieldName = binding[binding.length - 1];
+          object = parent.get(binding.slice(0, binding.length-1).join('.'));
+        } else {
+          fieldName = parent.get('label');
+          object = parent.get('context');
+        }
 
-          if (path) {
-            path = path.split(".");
-            path = path[path.length - 1];
-          } else {
-            path = parent.get('label');
-          }
+        if (object && !object.get('isValid')) {
+          var errors = object.get('errors');
 
-          if (errors !== undefined && path in errors) {
+          if (errors && fieldName in errors && errors[fieldName]) {
             parent.$().addClass('error');
-            this.$().html(errors[path].join(', '));
+            this.$().html(errors[fieldName].join(', '));
           } else {
             parent.$().removeClass('error');
             this.$().html('');

--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -86,7 +86,7 @@ Bootstrap.Forms.Field = Ember.View.extend({
         if (object && !object.get('isValid')) {
           var errors = object.get('errors');
 
-          if (errors && fieldName in errors && errors[fieldName]) {
+          if (errors && fieldName in errors && !Ember.isEmpty(errors[fieldName])) {
             parent.$().addClass('error');
             this.$().html(errors[fieldName].join(', '));
           } else {

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -86,7 +86,7 @@ test("should display the label errors", function() {
   ok(field.$().hasClass('error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
 
-  object.set('errors', {object: null});
+  object.set('errors', null);
   object.set('isValid', true);
   ok(!field.$().hasClass('error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
@@ -110,6 +110,17 @@ test("should display the field errors", function() {
 
   object.set('errors', {foo: null});
   object.set('isValid', true);
+  ok(!field.$().hasClass('error'), "the element should have the error tag");
+  equal(field.$().find('.errors').text(), "", "no error should be display anymore");
+  object.set('isValid', false);
+  ok(!field.$().hasClass('error'), "the element should have the error tag");
+  equal(field.$().find('.errors').text(), "", "no error should be display anymore");
+
+  object.set('errors', {foo: []});
+  object.set('isValid', true);
+  ok(!field.$().hasClass('error'), "the element should not have the error tag");
+  equal(field.$().find('.errors').text(), "", "no error should be display anymore");
+  object.set('isValid', false);
   ok(!field.$().hasClass('error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
 });
@@ -134,7 +145,7 @@ test("should display the nested object's field errors", function() {
   ok(field.$().hasClass('error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
 
-  object.set('bar.errors', {buz: null});
+  object.set('bar.errors', null);
   object.set('isValid', true);  // should listen on bar.isValid
   ok(!field.$().hasClass('error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -86,7 +86,7 @@ test("should display the label errors", function() {
   ok(field.$().hasClass('error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
 
-  object.set('errors', null);
+  object.set('errors', {object: null});
   object.set('isValid', true);
   ok(!field.$().hasClass('error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
@@ -108,11 +108,39 @@ test("should display the field errors", function() {
   ok(field.$().hasClass('error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
 
-  object.set('errors', null);
+  object.set('errors', {foo: null});
   object.set('isValid', true);
   ok(!field.$().hasClass('error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
 });
+
+test("should display the nested object's field errors", function() {
+  field.destroy();
+  field = null;
+  object = Ember.Object.create({
+    foo: null,
+    bar: Ember.Object.create({
+      buz: null
+    })
+  });
+  field = Bootstrap.Forms.Field.create({
+    context: object,
+    valueBinding: 'context.bar.buz'
+  });
+
+  append();
+  object.set('bar.errors', {buz: ["can't be null"]});
+  object.set('isValid', false);  // should listen on bar.isValid
+  ok(field.$().hasClass('error'), "the element should have the error tag");
+  equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
+
+  object.set('bar.errors', {buz: null});
+  object.set('isValid', true);  // should listen on bar.isValid
+  ok(!field.$().hasClass('error'), "the element should not have the error tag");
+  equal(field.$().find('.errors').text(), "", "no error should be display anymore");
+});
+
+
 
 test("should display the help", function() {
   append();


### PR DESCRIPTION
In PR #63 I've changed the way errors are looked up. However, this doesn't work for nested objects, as it currently will look in the parent for errors.

```
{{view Bootstrap.Forms.TextField valueBinding="address.city"}}
{{view Bootstrap.Forms.TextField valueBinding="bank.iban"}}
```

Both these fields will look for `city` and `iban` within `context`, but need to look respectively in `address` and `bank`. I've added tests for demonstration.

One drawback though, it will still look for `isValid` on the `context`. It is currently beyond my comprehension how I can create a dynamic `Ember.observer`.
