### PR TITLE
Triple stash the pager title so the arrows are not escaped

### DIFF
--- a/packages/ember-bootstrap/lib/views/pager.js
+++ b/packages/ember-bootstrap/lib/views/pager.js
@@ -18,7 +18,7 @@ Bootstrap.Pager = Ember.CollectionView.extend({
   },
   itemViewClass: Ember.View.extend(Bootstrap.ItemViewTitleSupport, Bootstrap.ItemViewHrefSupport, {
     classNameBindings: ["content.next", "content.previous", "content.disabled"],
-    template: Ember.Handlebars.compile('<a {{bindAttr href="view.href"}}>{{view.title}}</a>')
+    template: Ember.Handlebars.compile('<a {{bindAttr href="view.href"}}>{{{view.title}}}</a>')
   }),
   arrayDidChange: function(content, start, removed, added) {
     if (content) {


### PR DESCRIPTION
Fix for pr #64
