### PR TITLE
Add footerViewClass to Bootstrap.ModalPane

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -9,9 +9,13 @@ var modalPaneTemplate = [
 '</div>',
 '<div class="modal-body">{{view view.bodyViewClass}}</div>',
 '<div class="modal-footer">',
-'  {{#if view.secondary}}<a href="#" class="btn btn-secondary" rel="secondary">{{view.secondary}}</a>{{/if}}',
-'  {{#if view.primary}}<a href="#" class="btn btn-primary" rel="primary">{{view.primary}}</a>{{/if}}',
+'  {{view view.footerViewClass}}',
 '</div>'].join("\n");
+
+var footerTemplate = [
+'{{#if view.parentView.secondary}}<a href="#" class="btn btn-secondary" rel="secondary">{{view.parentView.secondary}}</a>{{/if}}',
+'{{#if view.parentView.primary}}<a href="#" class="btn btn-primary" rel="primary">{{view.parentView.primary}}</a>{{/if}}'].join("\n");
+
 var modalPaneBackdrop = '<div class="modal-backdrop"></div>';
 
 Bootstrap.ModalPane = Ember.View.extend({
@@ -29,6 +33,9 @@ Bootstrap.ModalPane = Ember.View.extend({
   bodyViewClass: Ember.View.extend({
     tagName: 'p',
     template: Ember.Handlebars.compile('{{{view.parentView.message}}}')
+  }),
+  footerViewClass: Ember.View.extend({
+    template: Ember.Handlebars.compile(footerTemplate)
   }),
 
   didInsertElement: function() {

--- a/packages/ember-bootstrap/tests/views/modal_pane_test.js
+++ b/packages/ember-bootstrap/tests/views/modal_pane_test.js
@@ -88,6 +88,17 @@ test("a modal pane defines secondary button first so it sits to the left of the 
   ok(modalPane.$().find('.modal-footer a.btn-secondary').next('a.btn-primary'), 'a modal pane defines secondary button first');
 });
 
+test("a modal pane footerViewClass may be extended", function() {
+  modalPane = Bootstrap.ModalPane.create({
+    footerViewClass: Ember.View.extend({
+      classNames: ['custom-footer'],
+      template: Ember.Handlebars.compile('custom footer')
+    })
+  });
+  appendIntoDOM(modalPane);
+  equal(modalPane.$().find('.modal-footer .custom-footer').text(), 'custom footer');
+});
+
 test("a modal pane does not get removed by clicking inside it", function() {
   modalPane = Bootstrap.ModalPane.create();
   appendIntoDOM(modalPane);


### PR DESCRIPTION
add footerViewClass to Bootstrap.ModalPane view so footer can be easily extended. 
