### PR TITLE
Multiple fixes: code styles + properties to Array + fix rendering context for breadcrumbs

### DIFF
--- a/packages/ember-bootstrap/lib/forms/checkbox.js
+++ b/packages/ember-bootstrap/lib/forms/checkbox.js
@@ -5,7 +5,7 @@ Bootstrap.Forms.Checkbox = Bootstrap.Forms.Field.extend({
     attributeBindings: ['name'],
     checkedBinding:   'parentView.checked',
     disabledBinding: 'parentView.disabled',
-    classNameBindings: 'parentView.inputClassNames',
+    classNameBindings: ['parentView.inputClassNames'],
     name: Ember.computed(function() {
       return this.get('parentView.name') || this.get('parentView.label');
     }).property('parentView.name', 'parentView.label')

--- a/packages/ember-bootstrap/lib/forms/select.js
+++ b/packages/ember-bootstrap/lib/forms/select.js
@@ -15,7 +15,7 @@ Bootstrap.Forms.Select = Bootstrap.Forms.Field.extend({
     promptBinding:          'parentView.prompt',
     multipleBinding:        'parentView.multiple',
     disabledBinding:        'parentView.disabled',
-    classNameBindings:      'parentView.inputClassNames',
+    classNameBindings:      ['parentView.inputClassNames'],
     name: Ember.computed(function() {
       return this.get('parentView.name') || this.get('parentView.label');
     }).property('parentView.name', 'parentView.label')    

--- a/packages/ember-bootstrap/lib/forms/uneditable_input.js
+++ b/packages/ember-bootstrap/lib/forms/uneditable_input.js
@@ -8,7 +8,7 @@ Bootstrap.Forms.UneditableInput = Bootstrap.Forms.Field.extend({
     template: Ember.Handlebars.compile('{{view.value}}'),
 
     valueBinding:   'parentView.value',
-    classNameBindings: 'parentView.inputClassNames',
+    classNameBindings: ['parentView.inputClassNames'],
     name: Ember.computed(function() {
       return this.get('parentView.name') || this.get('parentView.label');
     }).property('parentView.name', 'parentView.label')

--- a/packages/ember-bootstrap/lib/mixins/first_last_view_support.js
+++ b/packages/ember-bootstrap/lib/mixins/first_last_view_support.js
@@ -3,13 +3,16 @@ var Bootstrap = window.Bootstrap;
 
 Bootstrap.FirstLastViewSupport = Ember.Mixin.create({
   createChildView: function(view, attrs) {
+    var content;
+
     if (attrs) {
-      var content = get(this, "content");
+      content = get(this, 'content');
+
       if (attrs.contentIndex === 0) {
-        view = get(this, "firstItemViewClass") || view;
+        view = get(this, 'firstItemViewClass') || view;
       }
-      if (attrs.contentIndex === (content.get("length") - 1)) {
-        view = get(this, "lastItemViewClass") || view;
+      if (attrs.contentIndex === (get(content, 'length') - 1)) {
+        view = get(this, 'lastItemViewClass') || view;
       }
     }
     return this._super(view, attrs);

--- a/packages/ember-bootstrap/lib/mixins/item_view_href_support.js
+++ b/packages/ember-bootstrap/lib/mixins/item_view_href_support.js
@@ -8,7 +8,7 @@ Bootstrap.ItemViewHrefSupport = Ember.Mixin.create({
     content = get(this, 'content');
     if (parentView) {
       hrefKey = get(parentView, 'itemHrefKey') || 'link';
-      return get(content, hrefKey) || "#";
+      return get(content, hrefKey) || '#';
     }
     return content;
   }).property('content').cacheable()

--- a/packages/ember-bootstrap/lib/mixins/item_view_title_support.js
+++ b/packages/ember-bootstrap/lib/mixins/item_view_title_support.js
@@ -1,15 +1,19 @@
-var get = Ember.get;
-var Bootstrap = window.Bootstrap;
+var get = Ember.get, 
+    Bootstrap = window.Bootstrap;
 
 Bootstrap.ItemViewTitleSupport = Ember.Mixin.create({
   title: Ember.computed(function() {
     var parentView = get(this, 'parentView'),
-        content, titleKey;
+        content, 
+        titleKey;
+
     content = get(this, 'content');
     if (parentView) {
       titleKey = get(parentView, 'itemTitleKey') || 'title';
+
       return get(content, titleKey) || content;
     }
+
     return content;
   }).property('content').cacheable()
 });

--- a/packages/ember-bootstrap/lib/mixins/size_support.js
+++ b/packages/ember-bootstrap/lib/mixins/size_support.js
@@ -3,11 +3,11 @@ var Bootstrap = window.Bootstrap;
 
 Bootstrap.SizeSupport = Ember.Mixin.create({
   baseClassName: Ember.required(String),
-  classNameBindings: "sizeClass",
+  classNameBindings: ['sizeClass'],
   size: null, // mini, small || large
   sizeClass: Ember.computed(function() {
-    var size = get(this, "size"),
-        baseClassName = get(this, "baseClassName");
-    return size ? baseClassName + "-" + size : null;
-  }).property("size").cacheable()
+    var size = get(this, 'size'),
+        baseClassName = get(this, 'baseClassName');
+    return size ? baseClassName + '-' + size : null;
+  }).property('size').cacheable()
 });

--- a/packages/ember-bootstrap/lib/mixins/type_support.js
+++ b/packages/ember-bootstrap/lib/mixins/type_support.js
@@ -3,11 +3,11 @@ var Bootstrap = window.Bootstrap;
 
 Bootstrap.TypeSupport = Ember.Mixin.create({
   baseClassName: Ember.required(String),
-  classNameBindings: "typeClass",
+  classNameBindings: ['typeClass'],
   type: null, // success, warning, error, info || inverse
   typeClass: Ember.computed(function() {
-    var type = get(this, "type"),
-        baseClassName = get(this, "baseClassName");
-    return type ? baseClassName + "-" + type : null;
-  }).property("type").cacheable()
+    var type = get(this, 'type'),
+        baseClassName = get(this, 'baseClassName');
+    return type ? baseClassName + '-' + type : null;
+  }).property('type').cacheable()
 });

--- a/packages/ember-bootstrap/lib/views/badge.js
+++ b/packages/ember-bootstrap/lib/views/badge.js
@@ -1,9 +1,9 @@
-require("ember-bootstrap/mixins/type_support");
+require('ember-bootstrap/mixins/type_support');
 
 var Bootstrap = window.Bootstrap;
 Bootstrap.Badge = Ember.View.extend(Bootstrap.TypeSupport, {
-  tagName: "span",
-  classNames: "badge",
-  baseClassName: "badge",
-  template: Ember.Handlebars.compile("{{view.content}}")
+  tagName: 'span',
+  classNames: ['badge'],
+  baseClassName: 'badge',
+  template: Ember.Handlebars.compile('{{view.content}}')
 });

--- a/packages/ember-bootstrap/lib/views/breadcrumb.js
+++ b/packages/ember-bootstrap/lib/views/breadcrumb.js
@@ -1,18 +1,77 @@
-require("ember-bootstrap/mixins/item_view_title_support");
-require("ember-bootstrap/mixins/first_last_view_support");
+require('ember-bootstrap/mixins/item_view_title_support');
+require('ember-bootstrap/mixins/first_last_view_support');
 
 var get = Ember.get;
 var Bootstrap = window.Bootstrap;
 
 Bootstrap.Breadcrumb = Ember.CollectionView.extend(Bootstrap.FirstLastViewSupport, {
-  tagName: "ul",
-  classNames: "breadcrumb",
-  divider: "/",
+  tagName: 'ul',
+  classNames: ['breadcrumb'],
+  divider: '/',
+  arrayDidChange: function(content, start, removed, added) {
+    var view, 
+        index, 
+        length,
+        item,
+        lastItemViewClass = get(this, 'lastItemViewClass'),
+        itemViewClass = get(this, 'itemViewClass'),
+        lastView;
+
+    this._super.apply(this, arguments);
+
+    if (!content)
+      return;
+
+    length = get(content, 'length');
+
+    if (removed) {
+      lastView = get(this, 'childViews.lastObject');
+
+      if (lastItemViewClass.detectInstance(lastView))
+        return;
+
+      index = length - 1;
+
+      view = this.createChildView(lastItemViewClass, {
+        content: content[index],
+        contentIndex: index
+      });
+
+      this.replace(index, 1, [view]);
+    }
+
+    if (added) {
+      get(this, 'childViews').forEach(function(childView, index) {
+        if (lastItemViewClass.detectInstance(childView) && index !== length - 1) {
+          view = this.createChildView(itemViewClass, {
+            content: content[index],
+            contentIndex: index
+          });
+
+          this.replace(index, 1, [view]);
+        }
+      }, this);
+
+    }
+
+  },
   itemViewClass: Ember.View.extend(Bootstrap.ItemViewTitleSupport, {
-    template: Ember.Handlebars.compile('<a href="#">{{title}}</a><span class="divider">{{view.parentView.divider}}</span>')
+    template: Ember.Handlebars.compile('<a href="#">{{view.title}}</a><span class="divider">{{view.parentView.divider}}</span>')
   }),
   lastItemViewClass: Ember.View.extend(Bootstrap.ItemViewTitleSupport, {
-    classNames: "active",
-    template: Ember.Handlebars.compile("{{title}}")
+    classNames: ['active'],
+    template: Ember.Handlebars.compile('{{view.title}}')
   })
 });
+
+// 1 2 3 
+// 1 2 3 4 5 6
+// [] 3 0 3
+
+// 1 2 3 
+// 1 2 3 4
+// [] 3 0 1
+
+
+
+

--- a/packages/ember-bootstrap/lib/views/label.js
+++ b/packages/ember-bootstrap/lib/views/label.js
@@ -1,9 +1,9 @@
-require("ember-bootstrap/mixins/type_support");
+require('ember-bootstrap/mixins/type_support');
 var Bootstrap = window.Bootstrap;
 
 Bootstrap.Label = Ember.View.extend(Bootstrap.TypeSupport, {
-  tagName: "span",
-  classNames: "label",
-  baseClassName: "label",
-  template: Ember.Handlebars.compile("{{view.content}}")
+  tagName: 'span',
+  classNames: ['label'],
+  baseClassName: 'label',
+  template: Ember.Handlebars.compile('{{view.content}}')
 });

--- a/packages/ember-bootstrap/lib/views/pager.js
+++ b/packages/ember-bootstrap/lib/views/pager.js
@@ -1,28 +1,28 @@
-require("ember-bootstrap/mixins/item_view_title_support");
-require("ember-bootstrap/mixins/item_view_href_support");
+require('ember-bootstrap/mixins/item_view_title_support');
+require('ember-bootstrap/mixins/item_view_href_support');
 
 var Bootstrap = window.Bootstrap;
 Bootstrap.Pager = Ember.CollectionView.extend({
-  tagName: "ul",
-  classNames: "pager",
-  itemTitleKey: "title",
-  itemHrefKey: "href",
+  tagName: 'ul',
+  classNames: ['pager'],
+  itemTitleKey: 'title',
+  itemHrefKey: 'href',
   init: function() {
     this._super();
-    if (!this.get("content")) {
-      this.set("content", Ember.A([
-                                  Ember.Object.create({ title: "&larr;" }), 
-                                  Ember.Object.create({ title: "&rarr;" })
+    if (!this.get('content')) {
+      this.set('content', Ember.A([
+                                  Ember.Object.create({ title: '&larr;' }), 
+                                  Ember.Object.create({ title: '&rarr;' })
       ]));
     }
   },
   itemViewClass: Ember.View.extend(Bootstrap.ItemViewTitleSupport, Bootstrap.ItemViewHrefSupport, {
-    classNameBindings: ["content.next", "content.previous", "content.disabled"],
+    classNameBindings: ['content.next', 'content.previous', 'content.disabled'],
     template: Ember.Handlebars.compile('<a {{bindAttr href="view.href"}}>{{{view.title}}}</a>')
   }),
   arrayDidChange: function(content, start, removed, added) {
     if (content) {
-      Ember.assert("content must always has at the most 2 elements", content.get("length") <= 2);
+      Ember.assert('content must always has at the most 2 elements', content.get('length') <= 2);
     }
     return this._super(content, start, removed, added);
   }

--- a/packages/ember-bootstrap/lib/views/pagination.js
+++ b/packages/ember-bootstrap/lib/views/pagination.js
@@ -1,22 +1,22 @@
-require("ember-bootstrap/mixins/item_selection_support");
-require("ember-bootstrap/mixins/item_view_href_support");
+require('ember-bootstrap/mixins/item_selection_support');
+require('ember-bootstrap/mixins/item_view_href_support');
 
 var get = Ember.get, set = Ember.set, A = Ember.A;
 var Bootstrap = window.Bootstrap;
 
 Bootstrap.Pagination = Ember.CollectionView.extend({
-  tagName: "ul",
-  classNames: "pagination",
-  itemTitleKey: "title",
-  itemHrefKey: "href",
+  tagName: 'ul',
+  classNames: ['pagination'],
+  itemTitleKey: 'title',
+  itemHrefKey: 'href',
   init: function() {
     this._super();
-    if (!this.get("content")) {
-      this.set("content", new A([]));
+    if (!this.get('content')) {
+      this.set('content', new A([]));
     }
   },
   itemViewClass: Ember.View.extend(Bootstrap.ItemSelectionSupport, Bootstrap.ItemViewHrefSupport, {
-    classNameBindings: ["content.disabled"],
+    classNameBindings: ['content.disabled'],
     template: Ember.Handlebars.compile('<a {{bindAttr href="view.href"}}>{{view.title}}</a>')
   })
 });

--- a/packages/ember-bootstrap/lib/views/pill_item.js
+++ b/packages/ember-bootstrap/lib/views/pill_item.js
@@ -1,5 +1,5 @@
-require("ember-bootstrap/mixins/item_selection_support");
-require("ember-bootstrap/mixins/item_view_href_support");
+require('ember-bootstrap/mixins/item_selection_support');
+require('ember-bootstrap/mixins/item_view_href_support');
 
 var Bootstrap = window.Bootstrap;
 Bootstrap.PillItem = Ember.View.extend(Bootstrap.ItemSelectionSupport, Bootstrap.ItemViewHrefSupport, {

--- a/packages/ember-bootstrap/lib/views/progress_bar.js
+++ b/packages/ember-bootstrap/lib/views/progress_bar.js
@@ -1,4 +1,5 @@
 var get = Ember.get;
+var fmt = Ember.String.fmt;
 var Bootstrap = window.Bootstrap;
 
 Bootstrap.ProgressBar = Ember.View.extend({
@@ -11,6 +12,7 @@ Bootstrap.ProgressBar = Ember.View.extend({
 
   style: Ember.computed(function() {
     var progress = get(this, 'progress');
-    return "width:" + progress + "%;";
+    
+    return fmt('width:%@%;', [progress]);
   }).property('progress').cacheable()
 });

--- a/packages/ember-bootstrap/tests/views/breadcrumb_test.js
+++ b/packages/ember-bootstrap/tests/views/breadcrumb_test.js
@@ -1,10 +1,10 @@
 var get = Ember.get, set = Ember.set, A = Ember.A, run = Ember.run;
 var breadcrumb, single, many;
 
-module("Bootstrap.Breadcrumb", {
+module('Bootstrap.Breadcrumb', {
   setup: function() {
-    single = ['Home'];
-    many = ['Home', 'Library', 'Data'];
+    single = Ember.A(['Home']);
+    many = Ember.A(['Home', 'Library', 'Data']);
   },
   teardown: function() {
     run(function() {
@@ -13,7 +13,7 @@ module("Bootstrap.Breadcrumb", {
   }
 });
 
-test("a breadcrumb can be created, appended to DOM and is styled", function() {
+test('a breadcrumb can be created, appended to DOM and is styled', function() {
   breadcrumb = Bootstrap.Breadcrumb.create();
   appendIntoDOM(breadcrumb);
   ok(isAppendedToDOM(breadcrumb), 'a breadcrumb has a layer in the DOM');
@@ -26,31 +26,40 @@ test("a breadcrumb can be created, appended to DOM and is styled", function() {
 
 });
 
-test("a breadcrumb have children", function() {
+test('a breadcrumb have children', function() {
   breadcrumb = Bootstrap.Breadcrumb.create();
   appendIntoDOM(breadcrumb);
 
-  equal(breadcrumb.$().children().size(), 0, 'the breadcrumb with a single element does have a child');
+  equal(breadcrumb.$('li').size(), 0, 'the breadcrumb with a single element does have a child');
 
   run(function() {
-    set(breadcrumb, 'content', new A(single));
+    set(breadcrumb, 'content', single);
   });
-  equal(breadcrumb.$().children().size(), 1, 'the breadcrumb with a single element does have a child');
+  equal(breadcrumb.$('li').size(), 1, 'the breadcrumb with a single element does have a child');
 
   run(function() {
-    set(breadcrumb, 'content', new A(many));
+    set(breadcrumb, 'content', many);
   });
-  equal(breadcrumb.$().children().size(), 3, 'the breadcrumb with 3 elements have 3 children');
+  equal(breadcrumb.$('li').size(), 3, 'the breadcrumb with 3 elements have 3 children');
+  equal(breadcrumb.$('a:first').text(), 'Home', 'the breadcrumb first item has text === Home and its and anchor');
+  equal(breadcrumb.$('li:last').text(), 'Data', 'the breadcrumb last item has text === Data and does not have an anchor');
 
   run(function() {
-    get(breadcrumb, 'content').addObject('Another');
+    get(breadcrumb, 'content').pushObject('Another');
   });
-  equal(breadcrumb.$().children().size(), 4, 'the breadcrumb with 3 elements have 3 children');
+  equal(breadcrumb.$('li').size(), 4, 'the breadcrumb with 4 elements have 4 children');
+  equal(breadcrumb.$('a').size(), 3, 'the breadcrumb with 4 elements have 3 children with anchors');
+
+  run(function() {
+    get(breadcrumb, 'content').removeObject('Another');
+  });
+  equal(breadcrumb.$('li').size(), 3, 'the breadcrumb with 3 elements have 3 children');
+  equal(breadcrumb.$('a').size(), 2, 'the breadcrumb with 3 elements have 2 children with anchors');
 
 
 });
 
-test("a breadcrumb have divider", function() {
+test('a breadcrumb have divider', function() {
   breadcrumb = Bootstrap.Breadcrumb.create();
   appendIntoDOM(breadcrumb);
   equal(breadcrumb.get('divider'), '/', 'a breadcrumb has / as default divider (test for backward compatibility).');


### PR DESCRIPTION
- Convert properties to Array and apply code styles
  - There are some properties like classNames, attributesBindings and
    classNameBindings that should be Arrays. This commit converts them to
    Array.
  - This project does not have code style guide, however I noticed a lot of
    double quotes mixed with single quotes. This commit converts some
    double quotes to single quotes. It will make the life easier for
    contributors.
- Fix context rendering for breadcrumb templates, fix issue when items are added or removed to a breadcrumb and add tests.
  This commit fixes en issue reported in
  https://groups.google.com/forum/?fromgroups=#!topic/ember-bootstrap/rEgT
  g5q2M-8
  - Fixes rendering context for the templates used in breadcrumb
  - Adds regression tests to make sure this issue is not coming back
  - Fixes issue when item are added or removed from the breadcrumb content
