### PR TITLE
Promisify Bootstrap.ModalPane

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -18,7 +18,7 @@ var footerTemplate = [
 
 var modalPaneBackdrop = '<div class="modal-backdrop"></div>';
 
-Bootstrap.ModalPane = Ember.View.extend({
+Bootstrap.ModalPane = Ember.View.extend(Ember.DeferredMixin, {
   classNames: 'modal',
   defaultTemplate: Ember.Handlebars.compile(modalPaneTemplate),
   heading: null,
@@ -85,12 +85,20 @@ Bootstrap.ModalPane = Ember.View.extend({
     jQuery(window.document).unbind('keyup', this._keyUpHandler);
   },
 
+  _resolveOrReject: function(options, event) {
+    if (options.primary) this.resolve(options, event);
+    else this.reject(options, event);
+  },
+
   _triggerCallbackAndDestroy: function(options, event) {
     var destroy;
     if (this.callback) {
       destroy = this.callback(options, event);
     }
-    if (destroy === undefined || destroy) this.destroy();
+    if (destroy === undefined || destroy) {
+      this._resolveOrReject(options, event);
+      this.destroy();
+    }
   }
 });
 

--- a/packages/ember-bootstrap/tests/views/modal_pane_test.js
+++ b/packages/ember-bootstrap/tests/views/modal_pane_test.js
@@ -126,6 +126,56 @@ test("a modal pane calls callback when close button clicked", function() {
   ok(isDestroyed(modalPane), "modal pane is destroyed");
 });
 
+test("a modal pane resolves when primary button is clicked", function() {
+  stop();
+
+  modalPane = Bootstrap.ModalPane.create({
+    primary: 'Save'
+  });
+  appendIntoDOM(modalPane);
+  modalPane.then(function() {
+    start();
+  });
+  clickRelLink(modalPane, 'primary');
+});
+
+test("a modal pane rejects when close button is clicked", function() {
+  stop();
+
+  modalPane = Bootstrap.ModalPane.create();
+  appendIntoDOM(modalPane);
+  modalPane.then(null, function() {
+    start();
+  });
+  clickRelLink(modalPane, 'close');
+});
+
+test("a modal pane rejects when secondary button is clicked", function() {
+  stop();
+
+  modalPane = Bootstrap.ModalPane.create({
+    secondary: 'Cancel'
+  });
+  appendIntoDOM(modalPane);
+  modalPane.then(null, function() {
+    start();
+  });
+  clickRelLink(modalPane, 'secondary');
+});
+
+test("returning false from the callback does not resolve or reject the modal pane", function() {
+  modalPane = Bootstrap.ModalPane.create({
+    primary: 'Save',
+    callback: function() { return false; }
+  });
+  appendIntoDOM(modalPane);
+  modalPane.then(function() { ok(false, "should not resolve"); });
+  modalPane.then(null, function() { ok(false, "should not reject"); });
+  clickRelLink(modalPane, 'primary');
+  ok(isAppendedToDOM(modalPane), "modal pane is not in the DOM");
+  ok(!isDestroyed(modalPane), "modal pane is destroyed");
+});
+
 test("a modal pane calls callback when primary button clicked and removes pane from the DOM", function() {
   var callback = function() { callbackWasCalled = true; },
       callbackWasCalled = false;


### PR DESCRIPTION
A ModalPane now resolves when the `primary` button is clicked and
rejects on `secondary` or `close`.

This change allows you to write a dialog like this:

``` javascript
Bootstrap.ModalPane.popup({
  heading: 'You sure?',
  primary: 'Delete',
  secondary: 'Cancel'
}).then(function() {
  // primary button has been clicked
}, function() {
  // secondary button or dialog has been closed
});
```

The options and event are passed to the promise handler, so you can add
some additional logic:

``` javascript
Bootstrap.ModalPane.popup(...)
  .then(null, function(options, event) {
    if (options.secondary) {
      // dialog closed because secondary button clicked
    } else if (options.close) {
      // dialog closed by X
    }
  });
```
