### PR TITLE
Update the forms to Bootstrap 3

### DIFF
--- a/packages/ember-bootstrap/lib/forms/field.js
+++ b/packages/ember-bootstrap/lib/forms/field.js
@@ -1,15 +1,13 @@
 Bootstrap.Forms.Field = Ember.View.extend({
   tagName: 'div',
-  classNames: ['control-group'],
+  classNameBindings: ['form-group'],
   labelCache: undefined,
   help: undefined,
   template: Ember.Handlebars.compile([
     '{{view view.labelView viewName="labelView"}}',
-    '<div class="controls">',
-    '  {{view view.inputField viewName="inputField"}}',
-    '  {{view view.errorsView}}',
-    '  {{view view.helpView}}',
-    '</div>'].join("\n")),
+    '{{view view.inputField viewName="inputField"}}',
+    '{{view view.errorsView}}',
+    '{{view view.helpView}}'].join("\n")),
 
   label: Ember.computed(function(key, value) {
     if(arguments.length === 1){
@@ -56,7 +54,7 @@ Bootstrap.Forms.Field = Ember.View.extend({
   }),
 
   inputField: Ember.View.extend({
-    classNames: ['ember-bootstrap-extend'],
+    classNames: ['ember-bootstrap-extend', 'form-control'],
     tagName: 'div',
     template: Ember.Handlebars.compile('This class is not meant to be used directly, but extended.')
   }),
@@ -86,14 +84,14 @@ Bootstrap.Forms.Field = Ember.View.extend({
           var errors = object.get('errors');
 
           if (errors && fieldName in errors && !Ember.isEmpty(errors[fieldName])) {
-            parent.$().addClass('error');
+            parent.$().addClass('has-error');
             this.$().html(errors[fieldName].join(', '));
           } else {
-            parent.$().removeClass('error');
+            parent.$().removeClass('has-error');
             this.$().html('');
           }
         } else {
-          parent.$().removeClass('error');
+          parent.$().removeClass('has-error');
           this.$().html('');
         }
       }

--- a/packages/ember-bootstrap/tests/forms/field_test.js
+++ b/packages/ember-bootstrap/tests/forms/field_test.js
@@ -63,7 +63,7 @@ test("should use the valueBinding value as a default label", function() {
 
 test("should have the controls", function() {
   append();
-  equal(field.$().find('div.controls').length, 1, "Every field needs to include the controls");
+  equal(field.$().find('div.form-control').length, 1, "Every field needs to include the controls");
 });
 
 
@@ -82,12 +82,12 @@ test("should display the label errors", function() {
 
   object.set('errors', {object: ["can't be null"]});
   object.set('isValid', false);
-  ok(field.$().hasClass('error'), "the element should have the error tag");
+  ok(field.$().hasClass('has-error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
 
   object.set('errors', null);
   object.set('isValid', true);
-  ok(!field.$().hasClass('error'), "the element should not have the error tag");
+  ok(!field.$().hasClass('has-error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
 });
 
@@ -104,23 +104,23 @@ test("should display the field errors", function() {
   append();
   object.set('errors', {foo: ["can't be null"]});
   object.set('isValid', false);
-  ok(field.$().hasClass('error'), "the element should have the error tag");
+  ok(field.$().hasClass('has-error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
 
   object.set('errors', {foo: null});
   object.set('isValid', true);
-  ok(!field.$().hasClass('error'), "the element should have the error tag");
+  ok(!field.$().hasClass('has-error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
   object.set('isValid', false);
-  ok(!field.$().hasClass('error'), "the element should have the error tag");
+  ok(!field.$().hasClass('has-error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
 
   object.set('errors', {foo: []});
   object.set('isValid', true);
-  ok(!field.$().hasClass('error'), "the element should not have the error tag");
+  ok(!field.$().hasClass('has-error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
   object.set('isValid', false);
-  ok(!field.$().hasClass('error'), "the element should not have the error tag");
+  ok(!field.$().hasClass('has-error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
 });
 
@@ -141,12 +141,12 @@ test("should display the nested object's field errors", function() {
   append();
   object.set('bar.errors', {buz: ["can't be null"]});
   object.set('isValid', false);  // should listen on bar.isValid
-  ok(field.$().hasClass('error'), "the element should have the error tag");
+  ok(field.$().hasClass('has-error'), "the element should have the error tag");
   equal(field.$().find('.errors').text(), "can't be null", "the error should be displayed");
 
   object.set('bar.errors', null);
   object.set('isValid', true);  // should listen on bar.isValid
-  ok(!field.$().hasClass('error'), "the element should not have the error tag");
+  ok(!field.$().hasClass('has-error'), "the element should not have the error tag");
   equal(field.$().find('.errors').text(), "", "no error should be display anymore");
 });
 


### PR DESCRIPTION
This is the beta version for the forms updated to Bootstrap 3.
Since Bootstrap doesn't manage hints, nor error messages anymore, those are removed.

@Bouke: I'm mostly interested in your input on this, since the biggest possible point of failure is on errors with nested objects. Could you try it and check that nothing breaks on your side?
