### PR TITLE
adding bootstrap 3 .form-control class to textfields and textareas

### DIFF
--- a/packages/ember-bootstrap/lib/mixins/text_support.js
+++ b/packages/ember-bootstrap/lib/mixins/text_support.js
@@ -6,6 +6,7 @@ Bootstrap.TextSupport = Ember.Mixin.create({
   disabledBinding: 'parentView.disabled',
   maxlengthBinding: 'parentView.maxlength',
   classNameBindings: 'parentView.inputClassNames',
+  classNames: ['form-control'],
   attributeBindings: ['name'],
   name: Ember.computed(function() {
     return get(this, 'parentView.name') || get(this, 'parentView.label');

--- a/packages/ember-bootstrap/tests/forms/controls/text_area_test.js
+++ b/packages/ember-bootstrap/tests/forms/controls/text_area_test.js
@@ -27,6 +27,11 @@ test("should have the field", function() {
   equal(field.$().find('textarea').length, 1, "It needs to include the text area");
 });
 
+test("should have the class form-control", function() {
+  append();
+  equal(field.$().find('textarea.form-control').length, 1, "Textarea's need to have the class form-control");
+});
+
 test("input value is updated when setting value property of view", function() {
   Ember.run(function() {
     field.set('value', 'foo');

--- a/packages/ember-bootstrap/tests/forms/controls/text_field_test.js
+++ b/packages/ember-bootstrap/tests/forms/controls/text_field_test.js
@@ -27,6 +27,11 @@ test("should have the field", function() {
   equal(field.$().find('input[type=text]').length, 1, "It needs to include the text field");
 });
 
+test("should have the class form-control", function() {
+  append();
+  equal(field.$().find('input.form-control').length, 1, "Textfields need to have the form-control class");
+});
+
 test("input value is updated when setting value property of view", function() {
   Ember.run(function() {
     field.set('value', 'foo');


### PR DESCRIPTION
By default, [Bootstrap 3 textfields and textareas](http://getbootstrap.com/css/#forms-controls) require the class `.form-control`. Rather than adding this class in manually every time, I think it makes sense that we should add this class by default.
