### PR TITLE
Add flag to ModalPane which allows to hide close button

### DIFF
--- a/packages/ember-bootstrap/lib/views/modal_pane.js
+++ b/packages/ember-bootstrap/lib/views/modal_pane.js
@@ -2,7 +2,7 @@ var get = Ember.get;
 
 var modalPaneTemplate = [
 '<div class="modal-header">',
-'  <a href="#" class="close" rel="close">&times;</a>',
+'  {{#if view.showCloseButton}}<a href="#" class="close" rel="close">&times;</a>{{/if}}',
 '  {{view view.headerViewClass}}',
 '</div>',
 '<div class="modal-body">{{view view.bodyViewClass}}</div>',
@@ -26,6 +26,7 @@ Bootstrap.ModalPane = Ember.View.extend(Ember.DeferredMixin, {
   animateBackdropIn: null,
   animateBackdropOut: null,
   showBackdrop: true,
+  showCloseButton: true,
   headerViewClass: Ember.View.extend({
     tagName: 'h3',
     template: Ember.Handlebars.compile('{{view.parentView.heading}}')

--- a/packages/ember-bootstrap/tests/views/modal_pane_test.js
+++ b/packages/ember-bootstrap/tests/views/modal_pane_test.js
@@ -105,12 +105,21 @@ test("a modal pane does not get removed by clicking inside it", function() {
 });
 
 test("a modal pane has a close button that removes it from the DOM", function() {
-  var close;
   modalPane = Bootstrap.ModalPane.create();
   appendIntoDOM(modalPane);
   clickRelLink(modalPane, 'close');
   ok(!isAppendedToDOM(modalPane), "modal pane is not in the DOM");
   ok(isDestroyed(modalPane), "modal pane is destroyed");
+});
+
+test("the close button of a modal pane can be hidden by setting `showCloseButton` to false", function() {
+  modalPane = Bootstrap.ModalPane.create({
+    showCloseButton: false
+  });
+  appendIntoDOM(modalPane);
+  ok(modalPane.$().find("a.close").length === 0, "there is no close button");
+  modalPane.set("showCloseButton", true);
+  ok(modalPane.$().find("a.close").length === 1, "close button is shown after setting flag to false");
 });
 
 test("a modal pane calls callback when close button clicked", function() {


### PR DESCRIPTION
By setting the `showCloseButton` flag on a ModalPane to `false`, the close
button is hidden. It is hereby possible to create an unclosable ModalPane
which can be used to indicate ongoing activity, like "you're being logged in
..."
