### PR TITLE
Update ItemViewValueSupport to allow for falsy values.

### DIFF
--- a/packages/ember-bootstrap/lib/mixins/item_view_value_support.js
+++ b/packages/ember-bootstrap/lib/mixins/item_view_value_support.js
@@ -3,10 +3,11 @@ var get = Ember.get;
 Bootstrap.ItemViewValueSupport = Ember.Mixin.create({
   value: Ember.computed(function() {
     var parentView = get(this, 'parentView'),
-        content, valueKey;
+        content, valueKey, value;
     if (!parentView) return null;
     content = get(this, 'content');
     valueKey = get(parentView, 'itemValueKey') || 'value';
-    return get(content, valueKey) || content;
+    value = get(content, valueKey);
+    return value !== undefined ? value : content;
   }).property('content').cacheable()
 });


### PR DESCRIPTION
The existing method for calculating item values fails for falsy values like `null`, `0`, or `false`. I've updated ItemViewValueSupport to only default to the whole content object for the value when the calculated value === `undefined`.
